### PR TITLE
Small examples bug fixed

### DIFF
--- a/examples/sinatra-logging.rb
+++ b/examples/sinatra-logging.rb
@@ -5,7 +5,7 @@ require "cabin"
 require "logger"
 
 $logger = Cabin::Channel.new
-$logger.subscribe(Cabin.new(STDOUT))
+$logger.subscribe(Logger.new(STDOUT))
 
 def serve_it_up(arg)
   $logger.info("Serving it up")


### PR DESCRIPTION
I was working through the example code exploring cabin. The sinatra example failed as Cabin.new is an undefined method for the Cabin module. Changed this to Logger.new.
