### PR TITLE
Emit timer logs at specified log level

### DIFF
--- a/lib/cabin/channel.rb
+++ b/lib/cabin/channel.rb
@@ -120,6 +120,8 @@ class Cabin::Channel
       data = { :message => data }
     end
 
+    data[:level] = @level
+
     timer = Cabin::Timer.new do |duration|
       # TODO(sissel): Document this field
       data[:duration] = duration


### PR DESCRIPTION
I like the timer logs, however I'd love to be able to have different ones emitted at different levels. e.g. setup some DEBUG timers that I wouldn't normally want to know about.

This pull request isn't really ready to merge, but I wanted to discuss what I was trying to achieve :)

I've added the current log level into the timer log.

I'm not sure of the best way to proceed. I was thinking of sometime like:

logger.time("some_message", "level") { do_stuff }

And default the "level" to be :info.

But I can't work out how to call into the logger mixin so that I could check if the level matches the level we are logging at.

What do you think?
