### PR TITLE
concatenate filters of the superclass when Cabin::Channel is inherited

### DIFF
--- a/lib/cabin/channel.rb
+++ b/lib/cabin/channel.rb
@@ -50,6 +50,11 @@ class Cabin::Channel
   @channel_lock = Mutex.new
   @channels = Hash.new { |h,k| h[k] = Cabin::Channel.new }
 
+  # add superclass filters to subclass
+  def self.inherited(subclass)
+     subclass.filters.concat(self.filters)
+  end
+
   class << self
     # Get a channel for a given identifier. If this identifier has never been
     # used, a new channel is created for it.


### PR DESCRIPTION
this prevents missing filters which are being added by Timstamp mixin etc. when Cabin::Channel is inherited like Logstash::Logger  
