### PR TITLE
Add a "raw" output type to pass raw messages around

### DIFF
--- a/lib/cabin/channel.rb
+++ b/lib/cabin/channel.rb
@@ -6,6 +6,7 @@ require "cabin/namespace"
 require "cabin/context"
 require "cabin/outputs/stdlib-logger"
 require "cabin/outputs/io"
+require "cabin/outputs/raw"
 require "cabin/metrics"
 require "logger" # stdlib
 require "thread"

--- a/lib/cabin/outputs/raw.rb
+++ b/lib/cabin/outputs/raw.rb
@@ -1,0 +1,23 @@
+require 'cabin'
+require 'thread'
+
+# Wrap IO objects and log only the raw message
+#
+# This is added for particularly difficult use cases, such as
+# wanting to fork and exec a child procss, implicitly log the
+# data, and simultaneously capture it in a pipe for further
+# manipulation/analyzation
+
+class Cabin::Outputs::Raw
+  def initialize(io)
+    @io   = io
+    @lock = Mutex.new
+  end # def initialize(io)
+
+  def <<(event)
+    @lock.synchronize do
+      @io.puts event[:message]
+    end
+  end # def <<(event)
+end # class Cabin::Outputs::Raw
+

--- a/test/test_raw.rb
+++ b/test/test_raw.rb
@@ -1,0 +1,28 @@
+$: << File.dirname(__FILE__)
+$: << File.join(File.dirname(__FILE__), '..', 'lib')
+
+require 'rubygems'
+require 'minitest-patch'
+require 'cabin'
+require 'minitest/autorun' if __FILE__ == $0
+
+describe Cabin::Channel do
+  before do
+    @logger          = Cabin::Channel.new
+    @reader, @writer = IO.pipe
+    @target          = Cabin::Outputs::Raw.new(@writer)
+    @logger.subscribe(@target)
+  end
+
+  test "simple string publishing" do
+    @logger.publish('Hello world')
+    assert_equal("Hello world\n", @reader.readline)
+  end
+
+  test "ignores rich data" do
+    @logger[:foo] = 'bar'
+    @logger.publish('Hello world')
+    assert_equal("Hello world\n", @reader.readline)
+  end
+end
+


### PR DESCRIPTION
Enables some clever IPC tricks when spawning subprocesses and using
Cabin in the parent. In particular, it allows you to implicitly log a chlid process's output to Cabin while simultaneously copying the raw output into a pipe, so that it can be exposed for further analyzing/manipulation.
