### PR TITLE
Add block support to pipe()

### DIFF
--- a/lib/cabin/mixins/pipe.rb
+++ b/lib/cabin/mixins/pipe.rb
@@ -28,7 +28,7 @@ module Cabin::Mixins::Pipe
   #     write(1, "Fri Jan 11 22:49:42 PST 2013\n", 29) = 29 {"level":"error"}
   #     Fri Jan 11 22:49:42 PST 2013 {"level":"info"}
   #     +++ exited with 0 +++ {"level":"error"}
-  def pipe(io_to_method_map)
+  def pipe(io_to_method_map, &block)
     fds = io_to_method_map.keys
 
     while !fds.empty?
@@ -43,6 +43,7 @@ module Cabin::Mixins::Pipe
         end
 
         method_name = io_to_method_map[fd]
+        block.call(line, method_name) if block_given?
         send(method_name, line)
       end # readers.each
     end # while !fds.empty?

--- a/test/test_pipe.rb
+++ b/test/test_pipe.rb
@@ -1,0 +1,84 @@
+$: << File.dirname(__FILE__)
+$: << File.join(File.dirname(__FILE__), '..', 'lib')
+
+require 'rubygems'
+require 'minitest-patch'
+require 'cabin'
+require 'stringio'
+require 'minitest/autorun' if __FILE__ == $0
+
+describe Cabin::Channel do
+  class Receiver
+    attr_accessor :data
+
+    public
+    def initialize
+      @data = []
+    end
+
+    def <<(data)
+      @data << data
+    end
+  end # class Receiver
+
+  before do
+    @logger = Cabin::Channel.new
+    @target = Receiver.new
+    @logger.subscribe(@target)
+
+    @info_reader,  @info_writer  = IO.pipe
+    @error_reader, @error_writer = IO.pipe
+  end
+
+  after do
+    @logger.unsubscribe(@target.object_id)
+    [ @info_reader, @info_writer,
+      @error_reader, @error_writer ].each do |io|
+      io.close unless io.closed?
+    end
+  end
+
+  test 'Piping one IO' do
+    @info_writer.puts 'Hello world'
+    @info_writer.close
+
+    @logger.pipe(@info_reader => :info)
+    assert_equal(1, @target.data.length)
+    assert_equal('Hello world', @target.data[0][:message])
+  end
+
+  test 'Piping multiple IOs' do
+    @info_writer.puts 'Hello world'
+    @info_writer.close
+
+    @error_writer.puts 'Goodbye world'
+    @error_writer.close
+
+    @logger.pipe(@info_reader => :info, @error_reader => :error)
+    assert_equal(2, @target.data.length)
+    assert_equal('Hello world',   @target.data[0][:message])
+    assert_equal(:info,           @target.data[0][:level])
+    assert_equal('Goodbye world', @target.data[1][:message])
+    assert_equal(:error,          @target.data[1][:level])
+  end
+
+  test 'Piping with a block' do
+    @info_writer.puts 'Hello world'
+    @info_writer.close
+
+    @error_writer.puts 'Goodbye world'
+    @error_writer.close
+
+    info  = StringIO.new
+    error = StringIO.new
+
+    @logger.pipe(@info_reader => :info, @error_reader => :error) do |message, level|
+      info  << message if level == :info
+      error << message if level == :error
+    end
+
+    assert_equal('Hello world',   info.string)
+    assert_equal('Goodbye world', error.string)
+  end
+end
+


### PR DESCRIPTION
The pipe method now accepts a block, to which it passes 2 arguments:
- The line of text being logged
- The log level of the line

As discussed in #fpm on Freenode, this provides a more flexible, less clunky solution to the use case for #15.

Tests for piping are also present.
