### PR TITLE
Setting integer based log levels fails

### DIFF
--- a/lib/cabin/mixins/logger.rb
+++ b/lib/cabin/mixins/logger.rb
@@ -17,6 +17,8 @@ module Cabin::Mixins::Logger
   def level=(value)
     if value.respond_to?(:downcase)
       @level = value.downcase.to_sym
+    elsif value.is_a? Integer
+      @level = LEVELS.key(value)
     else
       @level = value.to_sym
     end


### PR DESCRIPTION
I'm writing an Logstash (SOAP) plugin which one of the libs (savon) supports using another logger for debug log.
When I set it to use `@logger` in logstash (i.e. cabin) it stackstraced because the savon set the log level with an integer, e.g. the Logger::WARN contant.

```
[…]
The error reported is:
  undefined method `to_sym' for 0:Fixnum
/Users/simlu/code/logstash/vendor/bundle/jruby/1.9/gems/cabin-0.6.1/lib/cabin/mixins/logger.rb:23:in `level='
/Users/simlu/code/logstash/vendor/bundle/jruby/1.9/gems/savon-2.7.2/lib/savon/options.rb:204:in `log_level'
/Users/simlu/code/logstash/vendor/bundle/jruby/1.9/gems/savon-2.7.2/lib/savon/options.rb:102:in `initialize'
/Users/simlu/code/logstash/vendor/bundle/jruby/1.9/gems/savon-2.7.2/lib/savon/client.rb:47:in `set_globals'
/Users/simlu/code/logstash/vendor/bundle/jruby/1.9/gems/savon-2.7.2/lib/savon/client.rb:15:in `initialize'
/Users/simlu/code/logstash/vendor/bundle/jruby/1.9/gems/savon-2.7.2/lib/savon.rb:10:in `client'
/Users/simlu/code/logstash/lib/logstash/outputs/soap.rb:38:in `register'
org/jruby/RubyArray.java:1613:in `each'
/Users/simlu/code/logstash/lib/logstash/pipeline.rb:158:in `start_outputs'
/Users/simlu/code/logstash/lib/logstash/pipeline.rb:79:in `run'
/Users/simlu/code/logstash/lib/logstash/agent.rb:139:in `execute'
/Users/simlu/code/logstash/lib/logstash/runner.rb:153:in `run'
org/jruby/RubyProc.java:271:in `call'
/Users/simlu/code/logstash/lib/logstash/runner.rb:158:in `run'
org/jruby/RubyProc.java:271:in `call'
/Users/simlu/code/logstash/vendor/bundle/jruby/1.9/gems/stud-0.0.17/lib/stud/task.rb:12:in `initialize'
```

This pull request fixes this.
