### PR TITLE
Flush logs heading to files on each event

### DIFF
--- a/lib/cabin/outputs/io.rb
+++ b/lib/cabin/outputs/io.rb
@@ -50,6 +50,7 @@ class Cabin::Outputs::IO
     @lock.synchronize do
       if !tty?
         @io.puts(event.inspect)
+        @io.flush
       else
         tty_write(event)
       end


### PR DESCRIPTION
I've had experience and also user reports of Logstash breaking with seemingly no error.
It seems when logging to a file (or redirected stdout which is not a terminal) the logs, potentially containing important error messages, are being buffered.

I believe this is the best fix and want to open discussion. Is this best way to handle it? Or do we prefer to bulk for few seconds? Would a test be preferred?

Thanks!