### PR TITLE
Allow passing blocks to the logger.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,7 @@
 PATH
   remote: .
   specs:
-    cabin (0.4.4)
-      json
+    cabin (0.7.1)
 
 GEM
   remote: http://rubygems.org/
@@ -10,7 +9,7 @@ GEM
     ffi (1.0.11)
     ffi-rzmq (0.9.3)
       ffi
-    json (1.6.5)
+    json (1.8.3)
     minitest (2.11.1)
     multi_json (1.0.4)
     simplecov (0.5.4)

--- a/lib/cabin/mixins/logger.rb
+++ b/lib/cabin/mixins/logger.rb
@@ -53,21 +53,10 @@ module Cabin::Mixins::Logger
       end
 
       return unless send(predicate)
+      return send(level, *block.call) if block
 
-      if block 
-        block_results = block.call
-
-        if block_results.is_a?(Array)
-          message, data = block_results
-          data ||= {}
-        else
-          message = block_results
-          data = {}
-        end
-      else
-        message = args[0]
-        data = args[1] || {}
-      end
+      message = args[0]
+      data = args[1] || {}
 
       if not data.is_a?(Hash)
         raise ::ArgumentError.new("#{self.class.name}##{level}(message, " \

--- a/test/test_logging.rb
+++ b/test/test_logging.rb
@@ -118,7 +118,7 @@ describe Cabin::Channel do
     level = level.to_sym
     test "block logging with data, '#{level}' logging when enabled" do
       @logger.level = level
-      @logger.send(level) { ["Hello world", {foo: 'bar'}] }
+      @logger.send(level) { ["Hello world", {:foo => 'bar'}] }
       event = @target.data[0]
       assert(@logger.send("#{level}?"),
              "At level #{level}, Channel##{level}? should return true.")
@@ -142,8 +142,8 @@ describe Cabin::Channel do
     level = level.to_sym
     test "block logging - doesn't execute block, '#{level}' logging when wrong level" do
       @logger.level = :fatal
-      # Should not log since log level is :fatal and we are above that.
-      @logger.send(level) { raise "I should not be evaluated"}
+      # Should not log or raise error since log level is :fatal and we are above that.
+      @logger.send(level) { raise 'I should not be evaluated' }
       assert_equal(0, @target.data.length)
     end
   end


### PR DESCRIPTION
The standard ruby logger allows passing a block. The purpose of this is so that log messages/data that include complex logic end up not being evaluated if they are at a level that would not print.
