### PR TITLE
Allow per subscriber logging level

### DIFF
--- a/cabin.gemspec
+++ b/cabin.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   paths = %w{lib examples test LICENSE CHANGELIST}
   spec.name = "cabin"
-  spec.version = "0.7.1"
+  spec.version = "0.8.0"
   spec.summary = "Experiments in structured and contextual logging"
   spec.description = "This is an experiment to try and make logging more " \
     "flexible and more consumable. Plain text logs are bullshit, let's " \

--- a/lib/cabin/channel.rb
+++ b/lib/cabin/channel.rb
@@ -80,12 +80,14 @@ class Cabin::Channel
     def actions
       @actions ||= []
     end # def Cabin::Channel.actions
+    alias_method(:filters, :actions) # DEPRECATED
 
     # Register a new action. The block is passed the event. It is expected to
     # modify that event or otherwise do nothing.
     def action(&block)
       actions << block
     end
+    alias_method(:filter, :action) # DEPRECATED
 
     # Get a list of conditions included in this class.
     def conditions

--- a/lib/cabin/mixins/logger.rb
+++ b/lib/cabin/mixins/logger.rb
@@ -5,12 +5,11 @@ require "cabin/namespace"
 module Cabin::Mixins::Logger
 
   def self.included(klass)
-    klass.filter do |event, subscription|
+    klass.condition do |event, subscription|
       if subscription.nil?
         true
       else
-        _output, options = subscription
-        LEVELS[(options[:level] || :debug)] >= LEVELS[event[:level]].to_i
+        LEVELS[(subscription.options[:level] || :debug)] >= LEVELS[event[:level]].to_i
       end
     end
   end

--- a/lib/cabin/mixins/logger.rb
+++ b/lib/cabin/mixins/logger.rb
@@ -3,6 +3,18 @@ require "cabin/namespace"
 # This module implements methods that act somewhat like Ruby's Logger class
 # It is included in Cabin::Channel
 module Cabin::Mixins::Logger
+
+  def self.included(klass)
+    klass.filter do |event, subscription|
+      if subscription.nil?
+        true
+      else
+        _output, options = subscription
+        LEVELS[(options[:level] || :debug)] >= LEVELS[event[:level]].to_i
+      end
+    end
+  end
+
   attr_accessor :level
   LEVELS = {
     :fatal => 0,

--- a/lib/cabin/mixins/terminal.rb
+++ b/lib/cabin/mixins/terminal.rb
@@ -3,7 +3,8 @@ require "cabin/namespace"
 module Cabin::Mixins::Terminal
 
   def terminal(message)
-    publish(message) do |output, event|
+    publish(message) do |subscriber, event|
+      output = subscriber.output
       output.respond_to?(:tty?) && output.tty?
     end
   end

--- a/lib/cabin/mixins/timestamp.rb
+++ b/lib/cabin/mixins/timestamp.rb
@@ -6,7 +6,7 @@ module Cabin::Mixins::Timestamp
     self.included(instance.class)
   end
   def self.included(klass)
-    klass.filter do |event|
+    klass.action do |event|
       event[:timestamp] = Time.now.strftime("%Y-%m-%dT%H:%M:%S.%6N%z")
     end
   end

--- a/lib/cabin/subscriber.rb
+++ b/lib/cabin/subscriber.rb
@@ -1,0 +1,11 @@
+class Cabin::Subscriber
+  attr :output, :options
+  def initialize(output, options = {})
+    @output = output
+    @options = options
+  end
+
+  def <<(data)
+    @output << data
+  end
+end

--- a/test/cabin/test_logging.rb
+++ b/test/cabin/test_logging.rb
@@ -62,6 +62,19 @@ describe Cabin::Channel do
     assert_equal("Hello world", @target.data[0][:message])
   end 
 
+  test "subscribe with a level impacts log publishing" do
+    sub1 = Receiver.new
+    sub2 = Receiver.new
+    @logger.subscribe(sub1, :level => :info)
+    @logger.subscribe(sub2, :level => :error)
+    @logger.debug("test debug")
+    @logger.info("test info")
+    @logger.error("test error")
+
+    assert_equal("test info", sub1.data[0][:message])
+    assert_equal("test error", sub1.data[1][:message])
+    assert_equal("test error", sub2.data[0][:message])
+  end
   test "context values" do
     context = @logger.context
     context["foo"] = "hello"


### PR DESCRIPTION
Introduces subscription logging levels to allow, for example, subscribing only to events of levels error and above.
The current concept of filters as broken as it served to execute actions before publishing an event, so this change:
* renames current filters to actions
* allows subscriptions to have extra options
* adds array of filter procs that are checked for each event and subscriptions
* logger mixin adds a filter proc that matches event log level to subscription log level

resolves #32 