### PR TITLE
make attr call compatible with 1.8

### DIFF
--- a/lib/cabin/subscriber.rb
+++ b/lib/cabin/subscriber.rb
@@ -1,5 +1,6 @@
 class Cabin::Subscriber
-  attr :output, :options
+  attr :output
+  attr :options
   def initialize(output, options = {})
     @output = output
     @options = options


### PR DESCRIPTION
in ruby 1.8 doing "attr :field1, :field2" is not supported, it's
necessary to create two lines:

    attr :field1
    attr :field2

fixes https://github.com/jordansissel/fpm/issues/1051