### PR TITLE
avoid explicit returns in define_method

### DIFF
--- a/lib/cabin/mixins/logger.rb
+++ b/lib/cabin/mixins/logger.rb
@@ -79,7 +79,7 @@ module Cabin::Mixins::Logger
     # these methods return true if the loglevel allows that level of log.
     define_method(predicate) do 
       @level ||= :info
-      return LEVELS[@level] >= LEVELS[level]
+      LEVELS[@level] >= LEVELS[level]
     end # def info?, def warn? ...
   end # end defining level-based log methods
 


### PR DESCRIPTION
in jruby 9k using explicit return in a define_method block makes the
code execution extremely slow due to its inability to optimize the code

see more: https://github.com/jruby/jruby/issues/3715