### PR TITLE
Add trace level logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source :rubygems
 
 gem "json"
-gem "ffi-rzmq"
 gem "minitest"
-gem "simplecov", :require => false, :group => "test"
 gemspec

--- a/lib/cabin/mixins/logger.rb
+++ b/lib/cabin/mixins/logger.rb
@@ -20,7 +20,8 @@ module Cabin::Mixins::Logger
     :error => 1,
     :warn => 2,
     :info => 3,
-    :debug => 4
+    :debug => 4,
+    :trace => 5
   }
 
   BACKTRACE_RE = /([^:]+):([0-9]+)(?::in `(.*)')?/
@@ -37,15 +38,14 @@ module Cabin::Mixins::Logger
   # Each level-based method accepts both a message and a hash data.
   #
   # This will define methods such as 'fatal' and 'fatal?' for each
-  # of: fatal, error, warn, info, debug
+  # of: fatal, error, warn, info, debug, trace
   #
   # The first method type (ie Cabin::Channel#fatal) is what logs, and it takes a
   # message and an optional Hash with context.
   #
   # The second method type (ie; Cabin::Channel#fatal?) returns true if
   # fatal logs are being emitted, false otherwise.
-  %w(fatal error warn info debug).each do |level|
-    level = level.to_sym
+  LEVELS.keys.each do |level|
     predicate = "#{level}?".to_sym
 
     # def info, def warn, etc...

--- a/test/cabin/test_logging.rb
+++ b/test/cabin/test_logging.rb
@@ -67,6 +67,7 @@ describe Cabin::Channel do
     sub2 = Receiver.new
     @logger.subscribe(sub1, :level => :info)
     @logger.subscribe(sub2, :level => :error)
+    @logger.trace("test trace")
     @logger.debug("test debug")
     @logger.info("test info")
     @logger.error("test error")
@@ -75,6 +76,7 @@ describe Cabin::Channel do
     assert_equal("test error", sub1.data[1][:message])
     assert_equal("test error", sub2.data[0][:message])
   end
+
   test "context values" do
     context = @logger.context
     context["foo"] = "hello"
@@ -174,4 +176,5 @@ describe Cabin::Channel do
     assert_equal("Hello world", event[:message])
     assert_equal(:info, event[:level])
   end
+
 end # describe Cabin::Channel do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,3 @@ require "support/minitest-patch"
 require "minitest/autorun"
 require "cabin"
 require "stringio"
-require "simplecov"
-
-SimpleCov.start


### PR DESCRIPTION
This adds `Cabin::Channel#trace` log method (and friends). `trace` more detailed than `debug`, so `debug` level setting will not show `trace` logs.

I also removed some old gems (ffi-rzmq) that we don't need and seem to make `bundle install` fail anyway (on MRI 2.2.1, in my testing), due to compile errors.